### PR TITLE
Fix GCC build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CC = gcc
 LD = $(CC)
 RM = rm
 
-CFLAGS = -g -Wall -O2
+CFLAGS = -g -Wall -O2 -std=c99 -D_POSIX_SOURCE
 LIBS = -lgnutls
 
 OBJECTS = x509lint.o checks.o messages.o

--- a/messages.c
+++ b/messages.c
@@ -66,13 +66,12 @@ static const char *info_strings[] = {
 char *get_messages()
 {
 	char *buffer;
-	int i;
 
 	/* Should be large enough for all strings. */
 	buffer = malloc(8192);
 	buffer[0] = '\0';
 
-	for (i = 0; i <= ERR_DATE_OUT_OF_RANGE; i++)
+	for (int i = 0; i <= ERR_DATE_OUT_OF_RANGE; i++)
 	{
 		if (GetBit(errors, i))
 		{
@@ -80,7 +79,7 @@ char *get_messages()
 		}
 	}
 
-	for (i = 0; i <= WARN_LONGER_39_MONTHS; i++)
+	for (int i = 0; i <= WARN_LONGER_39_MONTHS; i++)
 	{
 		if (i == WARN_IA5)
 		{
@@ -92,7 +91,7 @@ char *get_messages()
 		}
 	}
 
-	for (i = 0; i <= INF_CRL_NOT_URL; i++)
+	for (int i = 0; i <= INF_CRL_NOT_URL; i++)
 	{
 		if (i == INF_STRING_NOT_CHECKED)
 		{

--- a/messages.c
+++ b/messages.c
@@ -66,12 +66,13 @@ static const char *info_strings[] = {
 char *get_messages()
 {
 	char *buffer;
+	int i;
 
 	/* Should be large enough for all strings. */
 	buffer = malloc(8192);
 	buffer[0] = '\0';
 
-	for (int i = 0; i <= ERR_DATE_OUT_OF_RANGE; i++)
+	for (i = 0; i <= ERR_DATE_OUT_OF_RANGE; i++)
 	{
 		if (GetBit(errors, i))
 		{
@@ -79,7 +80,7 @@ char *get_messages()
 		}
 	}
 
-	for (int i = 0; i <= WARN_LONGER_39_MONTHS; i++)
+	for (i = 0; i <= WARN_LONGER_39_MONTHS; i++)
 	{
 		if (i == WARN_IA5)
 		{
@@ -91,7 +92,7 @@ char *get_messages()
 		}
 	}
 
-	for (int i = 0; i <= INF_CRL_NOT_URL; i++)
+	for (i = 0; i <= INF_CRL_NOT_URL; i++)
 	{
 		if (i == INF_STRING_NOT_CHECKED)
 		{


### PR DESCRIPTION
GCC 4.9.3 was failing with: ‘for’ loop initial declarations are only allowed in C99 or C11 mode."