### PR TITLE
Unconstify cert_buffer.

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -72,7 +72,7 @@ int GetBit(unsigned int *val, int bit)
 #define SetWarning(bit) SetBit(warnings, bit)
 #define SetInfo(bit) SetBit(info, bit)
 
-static X509 *LoadCert(const unsigned char *data, size_t len, CertFormat format)
+static X509 *LoadCert(unsigned char *data, size_t len, CertFormat format)
 {
 	X509 *x509;
 	BIO *bio = BIO_new_mem_buf(data, len);
@@ -670,7 +670,7 @@ static void CheckTime(X509 *x509)
 	}
 }
 
-void check(const unsigned char *cert_buffer, size_t cert_len, CertFormat format, CertType type)
+void check(unsigned char *cert_buffer, size_t cert_len, CertFormat format, CertType type)
 {
 	X509_NAME *issuer;
 	X509_NAME *subject;

--- a/checks.h
+++ b/checks.h
@@ -46,7 +46,7 @@ extern unsigned int warnings[1];
 extern unsigned int info[1];
 
 void check_init();
-void check(const unsigned char *cert_buffer, size_t cert_len, CertFormat format, CertType type);
+void check(unsigned char *cert_buffer, size_t cert_len, CertFormat format, CertType type);
 int GetBit(unsigned int *val, int bit);
 void check_finish();
 


### PR DESCRIPTION
I'm getting this warning with gcc 4.7.3:

checks.c:78:2: warning: passing argument 1 of ‘BIO_new_mem_buf’ discards ‘const’ qualifier from pointer target type [enabled by default]
In file included from /usr/include/openssl/evp.h:75:0,
                 from /usr/include/openssl/x509.h:73,
                 from checks.c:32:
/usr/include/openssl/bio.h:672:6: note: expected ‘void *’ but argument is of type ‘const unsigned char *’
