### PR TITLE
Constify obj_cmp parameters.

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -745,7 +745,7 @@ static void CheckTime(X509 *x509, struct tm *tm_before, struct tm *tm_after, Cer
 
 }
 
-static int obj_cmp(const ASN1_OBJECT **a, const ASN1_OBJECT **b)
+static int obj_cmp(const ASN1_OBJECT * const *a, const ASN1_OBJECT * const *b)
 {
 	return OBJ_cmp(*a, *b);
 }


### PR DESCRIPTION
On gcc 4.7.3:

gcc -g -Wall -O2 -std=c99 checks.c -c -o checks.o
checks.c: In function ‘CheckDuplicateExtentions’:
checks.c:755:33: warning: pointer type mismatch in conditional expression [enabled by default]
