### PR TITLE
Fix EKU stack type.

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -1222,7 +1222,7 @@ static void CheckEKU(X509 *x509)
 			break;
 		}
 
-		for (int i = 0; i < sk_DIST_POINT_num(ekus); i++)
+		for (int i = 0; i < sk_ASN1_OBJECT_num(ekus); i++)
 		{
 			ASN1_OBJECT *oid = sk_ASN1_OBJECT_value(ekus, i);
 			int nid = OBJ_obj2nid(oid);


### PR DESCRIPTION
I'm getting this warning with gcc-4.7.3:

checks.c: In function ‘CheckEKU’:
checks.c:1225:23: warning: pointer type mismatch in conditional expression [enabled by default]
