### PR TITLE
Check if X509_get_pubkey() returns NULL.

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -1348,6 +1348,11 @@ static void CheckSerial(X509 *x509)
 static void CheckPublicKey(X509 *x509, struct tm tm_after)
 {
 	EVP_PKEY *pkey = X509_get_pubkey(x509);
+	if (pkey == NULL)
+	{
+		SetError(ERR_INVALID);
+		return;
+	}
 	if (EVP_PKEY_base_id(pkey) == EVP_PKEY_RSA)
 	{
 		RSA *rsa = EVP_PKEY_get1_RSA(pkey);

--- a/checks.c
+++ b/checks.c
@@ -1350,10 +1350,9 @@ static void CheckPublicKey(X509 *x509, struct tm tm_after)
 	EVP_PKEY *pkey = X509_get_pubkey(x509);
 	if (pkey == NULL)
 	{
-		SetError(ERR_INVALID);
-		return;
+		SetError(ERR_UNKNOWN_PUBLIC_KEY_TYPE);
 	}
-	if (EVP_PKEY_base_id(pkey) == EVP_PKEY_RSA)
+	else if (EVP_PKEY_base_id(pkey) == EVP_PKEY_RSA)
 	{
 		RSA *rsa = EVP_PKEY_get1_RSA(pkey);
 
@@ -1411,7 +1410,7 @@ static void CheckPublicKey(X509 *x509, struct tm tm_after)
 		BN_CTX_free(ctx);
 		RSA_free(rsa);
 	}
-	if (EVP_PKEY_base_id(pkey) == EVP_PKEY_EC)
+	else if (EVP_PKEY_base_id(pkey) == EVP_PKEY_EC)
 	{
 		EC_KEY *ec_key = EVP_PKEY_get1_EC_KEY(pkey);
 		const EC_GROUP *group = EC_KEY_get0_group(ec_key);
@@ -1447,7 +1446,15 @@ static void CheckPublicKey(X509 *x509, struct tm tm_after)
 		BN_CTX_free(ctx);
 		EC_KEY_free(ec_key);
 	}
-	EVP_PKEY_free(pkey);
+	else
+	{
+		SetError(ERR_UNKNOWN_PUBLIC_KEY_TYPE);
+	}
+
+	if (pkey != NULL)
+	{
+		EVP_PKEY_free(pkey);
+	}
 }
 
 void check(unsigned char *cert_buffer, size_t cert_len, CertFormat format, CertType type)

--- a/checks.h
+++ b/checks.h
@@ -83,6 +83,7 @@ typedef enum { PEM, DER } CertFormat;
 #define ERR_EC_INVALID_GROUP_ORDER            73
 #define ERR_EC_INCORRECT_ORDER                74
 #define ERR_EC_NON_ALLOWED_CURVE              75
+#define ERR_UNKNOWN_PUBLIC_KEY_TYPE           76
 
 /* This violates a SHOULD (or MUST with exception that can't be checked) */
 #define WARN_NON_PRINTABLE_STRING      0

--- a/messages.c
+++ b/messages.c
@@ -102,6 +102,7 @@ static const char *error_strings[] =
 	"E: EC key has invalid group order\n", /* ERR_EC_INVALID_GROUP_ORDER */
 	"E: EC key has incorrect group order\n", /* ERR_EC_INCORRECT_ORDER */
 	"E: EC curve is not one of the allowed curves\n", /* ERR_EC_NON_ALLOWED_CURVE */
+	"E: Unknown public key type\n", /* ERR_UNKNOWN_PUBLIC_KEY_TYPE */
 };
 
 static const char *warning_strings[] = {
@@ -139,7 +140,7 @@ char *get_messages()
 	buffer = malloc(16384);
 	buffer[0] = '\0';
 
-	for (int i = 0; i <= ERR_EC_NON_ALLOWED_CURVE; i++)
+	for (int i = 0; i <= ERR_UNKNOWN_PUBLIC_KEY_TYPE; i++)
 	{
 		if (GetBit(errors, i))
 		{


### PR DESCRIPTION
A couple of WoSign certificates with SM2 (a Chinese EC algorithm) public keys have hit the CT logs.  Since OpenSSL doesn't support SM2, X509_get_pubkey() returns NULL, causing x509lint to segfault.

Here's one of the certs:
-----BEGIN CERTIFICATE-----
MIIDyjCCArKgAwIBAgIQFw3Ogq4ce+347rQBKUKAujANBgkqhkiG9w0BAQsFADBS
MQswCQYDVQQGEwJDTjEaMBgGA1UEChMRV29TaWduIENBIExpbWl0ZWQxJzAlBgNV
BAMTHldvU2lnbiBDbGFzcyAzIE9WIFNlcnZlciBDQSBHMjAeFw0xNTExMTMwNTEx
MjdaFw0xOTExMTMwNTExMjdaMB0xGzAZBgNVBAMMEnNtMnRlc3Qud29zaWduLm5l
dDBZMBMGByqGSM49AgEGCCqBHM9VAYItA0IABMxT4HFerWGOq7bkoFk00BK7+bmY
cFk0TI2ydY5ylC/fSEUyZy2ADcwyHoB5Pjd6kBZIX8o8Cgpj9BhbKuQBXnKjggGa
MIIBljALBgNVHQ8EBAMCBDAwHQYDVR0lBBYwFAYIKwYBBQUHAwIGCCsGAQUFBwMB
MB8GA1UdIwQYMBaAFPmL7AQ4aj+qBsaUrXOVKrDI5rj7MB0GA1UdDgQWBBSSBDPZ
lOXaNj5E5NHGXvYC8e71KjBzBggrBgEFBQcBAQRnMGUwLwYIKwYBBQUHMAGGI2h0
dHA6Ly9vY3NwMS53b3NpZ24uY29tL2NhNi9zZXJ2ZXIzMDIGCCsGAQUFBzAChiZo
dHRwOi8vYWlhMS53b3NpZ24uY29tL2NhNi5zZXJ2ZXIzLmNlcjA4BgNVHR8EMTAv
MC2gK6AphidodHRwOi8vY3JsczEud29zaWduLmNvbS9jYTYtc2VydmVyMy5jcmww
HQYDVR0RBBYwFIISc20ydGVzdC53b3NpZ24ubmV0ME8GA1UdIARIMEYwCAYGZ4EM
AQICMDoGDCsGAQQBgptRBgMCATAqMCgGCCsGAQUFBwIBFhxodHRwOi8vd3d3Lndv
c2lnbi5jb20vcG9saWN5MAkGA1UdEwQCMAAwDQYJKoZIhvcNAQELBQADggEBALI0
IS7A8DhmEJyguB5oJoEdQ394vhmbA9VqS8ojBkUhtEOm4gTBo8jYOZLJdQqzeKZ5
bgPtqlxbtw0wzDj5Mwar6QE45vyhm6pxGz9ScwI3SfYJ87lqzAdJLEiAErGd7ZIo
eiQ0PdCAdeEKyim1kdSDVCcx4kquThlTZefe0OF813Juf4vLoEAJ3fvO3+8gOnSF
5q4DmKqPuXfpeqtf3pT93258Q7n2Eu/WlQmddGjX7R+/aiLMuC0ZCcwoL4g/EKZi
4GfTSMsXHvriA9pwMycbVbVhC2AnSqWicGeFASOOGxx5rY14Q5Gxdof+Z0sPe/5R
XN7uBluDdok9UPCtxBw=
-----END CERTIFICATE-----
