### PR TITLE
Calculate UTF8String length correctly.

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -415,7 +415,8 @@ static bool CheckStringValid(ASN1_STRING *data, size_t *char_len)
 				{
 					ret = false;
 				}
-				(*char_len)--;	/* Don't count the BOM */
+				if (utf32[0] == 0xFEFF)
+					(*char_len)--;	/* Don't count the BOM */
 			}
 			free(utf32);
 		}

--- a/checks.c
+++ b/checks.c
@@ -396,7 +396,12 @@ static bool CheckStringValid(ASN1_STRING *data, size_t *char_len)
 
 			char *s = utf8;
 			size_t n = utf8_len;
-			size_t utf32_size = (utf8_len+1) * 4; /* It adds a BOM */
+			if (n >= 3 && s[0] == 0xEF && s[1] == 0xBB && s[2] == 0xBF)
+			{
+				s += 3; /* Ignore the BOM */
+				n -= 3;
+			}
+			size_t utf32_size = (n+1) * 4; /* It adds a BOM */
 			uint32_t *utf32 = malloc(utf32_size);
 			char *pu = (char *)utf32;
 

--- a/checks.c
+++ b/checks.c
@@ -415,6 +415,7 @@ static bool CheckStringValid(ASN1_STRING *data, size_t *char_len)
 				{
 					ret = false;
 				}
+				(*char_len)--;	/* Don't count the BOM */
 			}
 			free(utf32);
 		}


### PR DESCRIPTION
The organization name in this certificate is 64 characters long, but x509lint is complaining that it's >64 characters:
https://crt.sh/?id=30289778&opt=x509lint

x509lint calculates the length by converting the string to UTF-32 and dividing by 4.  However, there's an off-by-one error: the conversion to UTF-32 adds a BOM, which shouldn't be counted as a character in the UTF8String.