### PR TITLE
Use X.520's ub-postal-code upper bound.

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -446,7 +446,7 @@ static const struct
 	{ &obj_organizationalUnitName, 1, ub_organization_unit_name, ERR_ORGANIZATIONAL_UNIT_NAME_SIZE },
 	{ &obj_serialNumber, 1, 64, ERR_SERIAL_NUMBER_SIZE },
 	{ &obj_businessCategory, 1, ub_name, ERR_BUSINESS_CATEGORY_SIZE },
-	{ &obj_postalCode, 1, 16, ERR_POSTAL_CODE_SIZE },
+	{ &obj_postalCode, 1, 40, ERR_POSTAL_CODE_SIZE },
 	{ &obj_postOfficeBox, 1, 40, ERR_POST_OFFICE_BOX_SIZE },
 	{ &obj_StreetAddress, 1, 128, ERR_STREET_ADDRESS_SIZE },
 	{ &obj_dnQualifier, 1, ub_name, ERR_DN_QUALIFIER_SIZE }, /* Not sure */


### PR DESCRIPTION
https://crt.sh/?id=30511973&opt=x509lint
"ERROR: postalCode too long"

This cert's postal code is 17 characters.
RFC5280 defines "ub-postal-code-length INTEGER ::= 16".
X.520 defines "ub-postal-code INTEGER ::= 40".

As I mentioned in https://github.com/kroeckx/x509lint/issues/8, ISTM that all of the "ub-*-length" definitions in RFC5280 are only intended to apply to the ORAddress field of a GeneralName, so I believe that the maximum length of a postalCode field in a Subject or Issuer DN should be either 40 (since RFC5280 references X.520 informatively) or unlimited.