### PR TITLE
'=' is a permitted character in a PrintableString.

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -333,6 +333,7 @@ static bool CheckStringValid(ASN1_STRING *data, size_t *char_len)
 				(data->data[i] == '.') ||
 				(data->data[i] == '/') ||
 				(data->data[i] == ':') ||
+				(data->data[i] == '=') ||
 				(data->data[i] == '?') ||
 				(data->data[i] == ' ')))
 			{


### PR DESCRIPTION
https://crt.sh/?id=19406553&opt=x509lint currently shows a "Fails decoding the characterset" error due to the '=' character in the localityName.

http://www.itu.int/rec/T-REC-X.680-201508-I/en section 41.4, Table 10, says that '=' is a permitted character in a PrintableString.