### PR TITLE
Drop the WARN_POLICY_QUALIFIER_NOT_CPS lint.

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -842,10 +842,6 @@ static void CheckPolicy(X509 *x509, CertType type, X509_NAME *subject)
 					{
 						SetError(ERR_INVALID_POLICY_QUALIFIER_ID);
 					}
-					if (nid != NID_id_qt_cps)
-					{
-						SetWarning(WARN_POLICY_QUALIFIER_NOT_CPS);
-					}
 				}
 			}
 		}

--- a/checks.h
+++ b/checks.h
@@ -102,10 +102,9 @@ typedef enum { PEM, DER } CertFormat;
 #define WARN_EV_LONGER_12_MONTHS       7
 #define WARN_UNKNOWN_EKU               8
 #define WARN_RSA_EXP_RANGE             9
-#define WARN_POLICY_QUALIFIER_NOT_CPS 10
-#define WARN_EXPLICIT_TEXT_ENCODING   11
-#define WARN_NO_EKU                   12
-#define WARN_NO_CN                    13
+#define WARN_EXPLICIT_TEXT_ENCODING   10
+#define WARN_NO_EKU                   11
+#define WARN_NO_CN                    12
 
 /* Certificate is valid, but contains things like deprecated or not checked. */
 #define INF_SUBJECT_CN                    0

--- a/messages.c
+++ b/messages.c
@@ -122,7 +122,6 @@ static const char *warning_strings[] = {
 	"W: EV certificate valid longer than 12 months\n", /* WARN_EV_LONGER_12_MONTHS */
 	"W: Unknown extended key usage\n", /* WARN_UNKNOWN_EKU */
 	"W: RSA public exponent not in range of 2^16+1 to 2^256-1\n", /* WARN_RSA_EXP_RANGE */
-	"W: Policy information has qualifier other than CPS URI\n", /* WARN_POLICY_QUALIFIER_NOT_CPS */
 	"W: explicitText is not using a UTF8String\n", /* WARN_EXPLICIT_TEXT_ENCODING */
 	"W: Subscriber certificate without Extended Key Usage\n", /* WARN_NO_EKU */
 	"W: No commonName\n" /* WARN_NO_CN */


### PR DESCRIPTION
The WARN_POLICY_QUALIFIER_NOT_CPS lint currently triggers when a subscriber certificate contains the User Notice qualifier (id-qt 2 in RFC5280).  95% of the linting records on https://crt.sh/ are due to this lint, because it affects every certificate issued by Let's Encrypt.

BR 7.1.2.3 says that for a Subscriber Certificate (emphasis mine)...
> a. certificatePolicies
> This extension MUST be present and SHOULD NOT be marked critical.
>
> certificatePolicies:policyIdentifier	(Required)
> - A Policy Identifier, defined by the issuing CA, that indicates a Certificate Policy asserting the issuing CA's adherence to and compliance with these Requirements.
>
> The following **extensions** MAY be present:
>
> certificatePolicies:policyQualifiers:policyQualifierId	(Recommended)
> - id‐qt 1 [RFC 5280].
>
> certificatePolicies:policyQualifiers:qualifier:cPSuri (Optional)
> - HTTP URL for the Subordinate CA's Certification Practice Statement, Relying Party Agreement or other pointer to online information provided by the CA.

User Notice is not mentioned, which is presumably why the WARN_POLICY_QUALIFIER_NOT_CPS lint was added.  However...

- Calling policy qualifiers "extensions" arguably make this section entirely meaningless.
- Even if considered meaningful, I would argue that "MAY be present" doesn't imply that other policy qualifiers "MUST NOT be present".  Instead, I believe that it's appropriate to treat each other qualifier as an "other field" and apply BR 7.1.2.4, which says (emphasis mine)...
> All **other fields** and extensions MUST be set in accordance with RFC 5280.

RFC5280 4.2.1.4...
> RECOMMENDS that policy information terms consist of only an OID.

This capitalization of "RECOMMENDS" is either an error or a failed attempt to invoke the RFC2119 term "RECOMMENDED".  And in any case, x509lint doesn't warn when the CPS qualifier (id-qt 1) is present.

I conclude that it's acceptable to use the User Notice qualifier, and so this PR drops the WARN_POLICY_QUALIFIER_NOT_CPS lint.

RFC5280 4.2.1.4 goes on to say...
> Where an OID alone is insufficient, this profile strongly recommends that the use of qualifiers be limited to those identified in this section.

This is already implemented by the ERR_INVALID_POLICY_QUALIFIER_ID lint, which seems reasonable.