### PR TITLE
Add some name entry attributes: domainComponent, unstructuredName

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -512,7 +512,8 @@ static void CheckNameEntryValid(X509_NAME_ENTRY *ne)
 			SetError(ERR_INVALID_NAME_ENTRY_TYPE);
 		}
 	}
-	else if (nid == NID_pkcs9_unstructuredName && data->type == V_ASN1_IA5STRING) {
+	else if (nid == NID_pkcs9_unstructuredName && data->type == V_ASN1_IA5STRING)
+	{
 		/* PKCS#9 unstructuredName may be IA5String or DirectoryString */
 	}
 	else

--- a/checks.c
+++ b/checks.c
@@ -95,6 +95,7 @@ static ASN1_OBJECT *obj_serialNumber;
 static ASN1_OBJECT *obj_dnQualifier;
 static ASN1_OBJECT *obj_domainComponent;
 static ASN1_OBJECT *obj_pkcs9_emailAddress;
+static ASN1_OBJECT *obj_pkcs9_unstructuredName;
 static ASN1_OBJECT *obj_postOfficeBox;
 static ASN1_OBJECT *obj_anyEKU;
 static ASN1_OBJECT *obj_IntelAMTvProEKU;
@@ -471,6 +472,7 @@ static const struct
 	{ &obj_dnQualifier, 1, ub_name, ERR_DN_QUALIFIER_SIZE }, /* Not sure */
 	{ &obj_domainComponent, 1, 63, ERR_DOMAINCOMPONENT_SIZE },
 	{ &obj_pkcs9_emailAddress, 1, 255, ERR_EMAIL_SIZE },
+	{ &obj_pkcs9_unstructuredName, 1, 255, ERR_UNSTRUCTUREDNAME_SIZE },
 	{ &obj_givenName, 1, ub_name, ERR_GIVEN_NAME_SIZE },
 	{ &obj_surname, 1, 40, ERR_SURNAME_SIZE }
 };
@@ -509,6 +511,9 @@ static void CheckNameEntryValid(X509_NAME_ENTRY *ne)
 		{
 			SetError(ERR_INVALID_NAME_ENTRY_TYPE);
 		}
+	}
+	else if (nid == NID_pkcs9_unstructuredName && data->type == V_ASN1_IA5STRING) {
+		/* PKCS#9 unstructuredName may be IA5String or DirectoryString */
 	}
 	else
 	{
@@ -1686,6 +1691,7 @@ void check_init()
 	obj_dnQualifier = OBJ_nid2obj(NID_dnQualifier);
 	obj_domainComponent = OBJ_nid2obj(NID_domainComponent);
 	obj_pkcs9_emailAddress = OBJ_nid2obj(NID_pkcs9_emailAddress);
+	obj_pkcs9_unstructuredName = OBJ_nid2obj(NID_pkcs9_unstructuredName);
 
 	obj_jurisdictionCountryName = OBJ_txt2obj(OIDjurisdictionCountryName, 1);
 	obj_jurisdictionLocalityName = OBJ_txt2obj(OIDjurisdictionLocalityName, 1);

--- a/checks.c
+++ b/checks.c
@@ -93,6 +93,7 @@ static ASN1_OBJECT *obj_surname;
 static ASN1_OBJECT *obj_businessCategory;
 static ASN1_OBJECT *obj_serialNumber;
 static ASN1_OBJECT *obj_dnQualifier;
+static ASN1_OBJECT *obj_domainComponent;
 static ASN1_OBJECT *obj_pkcs9_emailAddress;
 static ASN1_OBJECT *obj_postOfficeBox;
 static ASN1_OBJECT *obj_anyEKU;
@@ -468,6 +469,7 @@ static const struct
 	{ &obj_postOfficeBox, 1, 40, ERR_POST_OFFICE_BOX_SIZE },
 	{ &obj_StreetAddress, 1, 128, ERR_STREET_ADDRESS_SIZE },
 	{ &obj_dnQualifier, 1, ub_name, ERR_DN_QUALIFIER_SIZE }, /* Not sure */
+	{ &obj_domainComponent, 1, 63, ERR_DOMAINCOMPONENT_SIZE },
 	{ &obj_pkcs9_emailAddress, 1, 255, ERR_EMAIL_SIZE },
 	{ &obj_givenName, 1, ub_name, ERR_GIVEN_NAME_SIZE },
 	{ &obj_surname, 1, 40, ERR_SURNAME_SIZE }
@@ -501,7 +503,7 @@ static void CheckNameEntryValid(X509_NAME_ENTRY *ne)
 		}
 	}
 
-	if (nid == NID_pkcs9_emailAddress)
+	if (nid == NID_pkcs9_emailAddress || nid == NID_domainComponent)
 	{
 		if (data->type != V_ASN1_IA5STRING)
 		{
@@ -1682,6 +1684,7 @@ void check_init()
 	obj_businessCategory = OBJ_nid2obj(NID_businessCategory);
 	obj_serialNumber = OBJ_nid2obj(NID_serialNumber);
 	obj_dnQualifier = OBJ_nid2obj(NID_dnQualifier);
+	obj_domainComponent = OBJ_nid2obj(NID_domainComponent);
 	obj_pkcs9_emailAddress = OBJ_nid2obj(NID_pkcs9_emailAddress);
 
 	obj_jurisdictionCountryName = OBJ_txt2obj(OIDjurisdictionCountryName, 1);

--- a/checks.h
+++ b/checks.h
@@ -91,6 +91,7 @@ typedef enum { PEM, DER } CertFormat;
 #define ERR_EMPTY_EKU                         81
 #define ERR_MISSING_EKU                       82
 #define ERR_DOMAINCOMPONENT_SIZE              83
+#define ERR_UNSTRUCTUREDNAME_SIZE             84
 
 /* This violates a SHOULD (or MUST with exception that can't be checked) */
 #define WARN_NON_PRINTABLE_STRING      0

--- a/checks.h
+++ b/checks.h
@@ -92,6 +92,7 @@ typedef enum { PEM, DER } CertFormat;
 #define ERR_MISSING_EKU                       82
 #define ERR_DOMAINCOMPONENT_SIZE              83
 #define ERR_UNSTRUCTUREDNAME_SIZE             84
+#define MAX_ERR                               ERR_UNSTRUCTUREDNAME_SIZE
 
 /* This violates a SHOULD (or MUST with exception that can't be checked) */
 #define WARN_NON_PRINTABLE_STRING      0
@@ -108,6 +109,7 @@ typedef enum { PEM, DER } CertFormat;
 #define WARN_EXPLICIT_TEXT_ENCODING   11
 #define WARN_NO_EKU                   12
 #define WARN_NO_CN                    13
+#define MAX_WARN                      WARN_NO_CN
 
 /* Certificate is valid, but contains things like deprecated or not checked. */
 #define INF_SUBJECT_CN                    0
@@ -115,6 +117,7 @@ typedef enum { PEM, DER } CertFormat;
 #define INF_CRL_NOT_URL                   2
 #define INF_UNKNOWN_VALIDATION            3        /* Software doesn't know OID yet. */
 #define INF_NAME_ENTRY_LENGTH_NOT_CHECKED 4        /* Software doesn't know how to check size yet. */
+#define MAX_INF                           INF_NAME_ENTRY_LENGTH_NOT_CHECKED
 
 extern uint32_t errors[];
 extern uint32_t warnings[];

--- a/checks.h
+++ b/checks.h
@@ -90,6 +90,7 @@ typedef enum { PEM, DER } CertFormat;
 #define ERR_ROOT_CA_WITH_EKU                  80
 #define ERR_EMPTY_EKU                         81
 #define ERR_MISSING_EKU                       82
+#define ERR_DOMAINCOMPONENT_SIZE              83
 
 /* This violates a SHOULD (or MUST with exception that can't be checked) */
 #define WARN_NON_PRINTABLE_STRING      0

--- a/messages.c
+++ b/messages.c
@@ -109,7 +109,8 @@ static const char *error_strings[] =
 	"E: CA root certificate with Extended Key Usage\n", /* ERR_ROOT_CA_WITH_EKU */
 	"E: Extended Key Usage without any entries\n", /* ERR_EMPTY_EKU */
 	"E: Extended Key Usage lacks a required purpose\n", /* ERR_MISSING_EKU */
-        "E: Invalid length of domainComponent", /* ERR_DOMAINCOMPONENT_SIZE */
+	"E: Invalid length of domainComponent", /* ERR_DOMAINCOMPONENT_SIZE */
+	"E: Invalid length of unstructuredName", /* ERR_UNSTRUCTUREDNAME_SIZE */
 };
 
 static const char *warning_strings[] = {

--- a/messages.c
+++ b/messages.c
@@ -150,7 +150,7 @@ char *get_messages()
 	buffer = malloc(16384);
 	buffer[0] = '\0';
 
-	for (int i = 0; i <= ERR_MISSING_EKU; i++)
+	for (int i = 0; i <= MAX_ERR; i++)
 	{
 		if (GetBit(errors, i))
 		{
@@ -158,7 +158,7 @@ char *get_messages()
 		}
 	}
 
-	for (int i = 0; i <= WARN_NO_CN; i++)
+	for (int i = 0; i <= MAX_WARN; i++)
 	{
 		if (GetBit(warnings, i))
 		{
@@ -166,7 +166,7 @@ char *get_messages()
 		}
 	}
 
-	for (int i = 0; i <= INF_NAME_ENTRY_LENGTH_NOT_CHECKED; i++)
+	for (int i = 0; i <= MAX_INF; i++)
 	{
 		if (GetBit(info, i))
 		{

--- a/messages.c
+++ b/messages.c
@@ -109,6 +109,7 @@ static const char *error_strings[] =
 	"E: CA root certificate with Extended Key Usage\n", /* ERR_ROOT_CA_WITH_EKU */
 	"E: Extended Key Usage without any entries\n", /* ERR_EMPTY_EKU */
 	"E: Extended Key Usage lacks a required purpose\n", /* ERR_MISSING_EKU */
+        "E: Invalid length of domainComponent", /* ERR_DOMAINCOMPONENT_SIZE */
 };
 
 static const char *warning_strings[] = {


### PR DESCRIPTION
@kroeckx x509lint assumes that all "unknown" attributes should be encoded as DirectoryStrings.  However, domainComponent is IA5String, and unstructuredName can be IA5String or DirectoryString.

We include both of these attribute types in certs occasionally, and we use x509lint for preissuance linting.  So it would be really useful to get this PR merged.