### PR TITLE
Update CheckSAN to not throw error when cert is Client Auth Only

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -934,7 +934,7 @@ static void CheckSAN(X509 *x509, CertType type)
 		name_type_allowed[i] = false;
 	}
 
-	if (GetBit(cert_info, CERT_INFO_SERV_AUTH) || GetBit(cert_info, CERT_INFO_ANY_EKU) || GetBit(cert_info, CERT_INFO_NO_EKU))
+	if (GetBit(cert_info, CERT_INFO_SERV_AUTH) || GetBit(cert_info, CERT_INFO_CLIENT_AUTH) || GetBit(cert_info, CERT_INFO_ANY_EKU) || GetBit(cert_info, CERT_INFO_NO_EKU))
 	{
 		name_type_allowed[GEN_DNS] = true;
 		name_type_allowed[GEN_IPADD] = true;


### PR DESCRIPTION
CA/B BR v1.5.6, 7.1.2.3.f allows conforming certificates to specify EKUs of Server Auth, or Client Auth, or Both. Therefore CheckSAN should not throw an error if only Client Auth is specified.