### PR TITLE
mod(Makefile): add support for Cygwin, requires LIBS += -liconv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,11 @@ RM = rm
 CFLAGS = -g -Wall -O2 -std=c99
 LIBS = -lcrypto
 
+UNAME_O := $(shell uname -o)
+ifeq ($(UNAME_O),Cygwin)
+    LIBS += -liconv
+endif
+
 OBJECTS = x509lint.o checks.o messages.o asn1_time.o
 
 x509lint: $(OBJECTS)


### PR DESCRIPTION
hi there.  cygwin needs iconv added to the LIBS to avoid "undefined reference to {`libiconv',`libiconv_open',`libiconv_close'}" errors during compile.