### PR TITLE
Reorder calls to CheckEKU() and CheckPolicy()

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -1704,8 +1704,8 @@ void check(unsigned char *cert_buffer, size_t cert_len, CertFormat format, CertT
 		SetError(ERR_SUBJECT_COUNTRY);
 	}
 
-	CheckPolicy(x509, type, subject);
 	CheckEKU(x509, type);
+	CheckPolicy(x509, type, subject);
 	CheckSAN(x509, type);
 
 	/* Deprecated in CAB base 7.1.4.2.2a */


### PR DESCRIPTION
The "Baseline Requirements policy present for non server authentication certificate" error for this certificate is incorrect:
https://crt.sh/?id=1568327559&opt=x509lint

At https://github.com/kroeckx/x509lint/blob/master/checks.c#L884, we see that CheckPolicy() expects CheckEKU() to have already been called.  But check() currently calls CheckPolicy() first.

This PR simply swaps the order of the function calls, so that CheckEKU() is called first.  This gets rid of the false positive error.