### PR TITLE
OCSP URL optional if CRL URL present or certificate is short-lived

### DIFF
--- a/checks.h
+++ b/checks.h
@@ -57,7 +57,7 @@ typedef enum { PEM, DER } CertFormat;
 #define ERR_SURNAME_SIZE                      46
 #define ERR_STREET_ADDRESS_SIZE               47
 #define ERR_AIA_CRITICAL                      48
-#define ERR_NO_OCSP_HTTP                      49
+#define ERR_NO_REVOCATION_HTTP                49
 #define ERR_NO_AIA                            50
 #define ERR_SAN_TYPE                          51
 #define ERR_GEN_NAME_TYPE                     52

--- a/messages.c
+++ b/messages.c
@@ -75,7 +75,7 @@ static const char *error_strings[] =
 	"E: surname too long\n", /* ERR_SURNAME_SIZE */
 	"E: streetAddress too long\n", /* ERR_STREET_ADDRESS_SIZE */
 	"E: authorityInformationAccess is marked critical\n", /* ERR_AIA_CRITICAL */
-	"E: No OCSP over HTTP\n",  /* ERR_NO_OCSP_HTTP */
+	"E: No CRL or OCSP over HTTP\n",  /* ERR_NO_REVOCATION_HTTP */
 	"E: no authorityInformationAccess extension\n", /* ERR_NO_AIA */
 	"E: Invalid type in SAN entry\n", /* ERR_SAN_TYPE */
 	"E: Invalid type in GeneralName\n", /* ERR_GEN_NAME_TYPE */


### PR DESCRIPTION
Since TLS BR v2.0.1, the inclusion of an OCSP URL in subscriber certificates has been optional (see "id-ad-ocsp...MAY" in section 7.1.2.7.7 (Subscriber Certificate Authority Information Access) ).

Section 7.1.2.7.6 (Subscriber Certificate Extensions) has this note:
> whether or not the CRL Distribution Points extension must be present
> depends on 1) whether the Certificate includes an Authority Information Access
> extension with an id-ad-ocsp accessMethod and 2) the Certificate’s validity period, as
> detailed in Section 7.1.2.11.2.

Section 7.1.2.11.2 (CRL Distribution Points) says:
> The CRL Distribution Points extension MUST be present in:
> ...
> • Subscriber Certificates that 1) do not qualify as “Short-lived Subscriber Certificates” and
> 2) do not include an Authority Information Access extension with an id-ad-ocsp
> accessMethod.

Currently x509lint emits an "E: No OCSP over HTTP" false positive for BR-compliant certificates that lack an OCSP URL.

This PR resolves that problem by implementing the new rules described above.