### PR TITLE
Suppress compiler warnings with OpenSSL 3.x

### DIFF
--- a/checks.c
+++ b/checks.c
@@ -30,6 +30,7 @@
 #include <stdint.h>
 #include <arpa/inet.h>
 
+#define OPENSSL_API_COMPAT 0x10100000L
 #include <openssl/x509.h>
 #include <openssl/x509v3.h>
 #include <openssl/pem.h>


### PR DESCRIPTION
Set OPENSSL_API_COMPAT to 1.1.0, to suppress compiler warnings when building against OpenSSL 3.x.

At some point it might be worth migrating x509lint to only use functions that aren't deprecated in OpenSSL 3.x (e.g., to support ML-DSA public keys), but for now I'd just like to make the build warnings go away.